### PR TITLE
cached invalid token triggers auth flow if causes websocket connectionn error

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "webpack": "^1.13.3",
     "ws": "^1.1.1"
   },
-  "build": "313",
+  "build": "316",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "webpack": "^1.13.3",
     "ws": "^1.1.1"
   },
-  "build": "316",
+  "build": "318",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comapi-sdk-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "test": "karma start --browsers=ChromeHeadless"
   },
@@ -50,6 +50,6 @@
     "webpack": "^1.13.3",
     "ws": "^1.1.1"
   },
-  "build": "293",
+  "build": "313",
   "license": "MIT"
 }

--- a/specs/401_retry.spec.ts
+++ b/specs/401_retry.spec.ts
@@ -51,6 +51,9 @@ describe("REST API 401 retry tests", () => {
         public restartSession(): Promise<ISessionInfo> { return Promise.resolve(this._sessionInfo); }
         public endSession(): Promise<boolean> { return Promise.resolve(true); }
         public ensureSession(): Promise<ISessionInfo> { return Promise.resolve(this._sessionInfo); }
+        public requestSession(): Promise<ISessionInfo> { return Promise.resolve(this._sessionInfo); }
+        public removeSession() { return Promise.resolve(false); }
+
     }
 
     let networkManager: MockNetworkManager;

--- a/specs/authenticatedRestClient.spec.ts
+++ b/specs/authenticatedRestClient.spec.ts
@@ -63,7 +63,7 @@ describe("AUTHENTICATED REST API TESTS", () => {
         let eventMapper = new EventMapper();
         let webSocketManager = new WebSocketManager(logger, localStorageData, comapiConfig, sessionManager, eventManager, eventMapper);
 
-        let networkManager = new NetworkManager(sessionManager, webSocketManager);
+        let networkManager = new NetworkManager(logger, sessionManager, webSocketManager);
 
         authenticatedRestClient = new AuthenticatedRestClient(logger, restClient, networkManager);
 

--- a/specs/interfaceManager.spec.ts
+++ b/specs/interfaceManager.spec.ts
@@ -51,6 +51,9 @@ describe("Foundation tests", () => {
             public startSession(): Promise<ISessionInfo> { return Promise.resolve(this.sessionInfo); }
             public endSession(): Promise<boolean> { return Promise.resolve(true); }
             public ensureSession(): Promise<ISessionInfo> { return Promise.resolve(this.sessionInfo); }
+            public requestSession(): Promise<ISessionInfo> { return Promise.resolve(this.sessionInfo); }
+            public removeSession() { return Promise.resolve(false); }
+
         }
         comapiConfig.interfaceContainer.initialise();
         comapiConfig.interfaceContainer.bindComapiConfig(comapiConfig);

--- a/specs/networkManager.spec.ts
+++ b/specs/networkManager.spec.ts
@@ -48,6 +48,9 @@ describe("networkManager tests", () => {
         public startSession(): Promise<ISessionInfo> { return Promise.resolve(this._sessionInfo); }
         public endSession(): Promise<boolean> { return Promise.resolve(true); }
         public ensureSession(): Promise<ISessionInfo> { return Promise.resolve(this.sessionInfo); }
+        public requestSession(): Promise<ISessionInfo> { return Promise.resolve(this.sessionInfo); }
+        public removeSession() { return Promise.resolve(false); }
+
     }
 
     class MockWebSocketManager implements IWebSocketManager {

--- a/specs/networkManager.spec.ts
+++ b/specs/networkManager.spec.ts
@@ -9,6 +9,9 @@ import {
     INetworkManager
 } from "../src/interfaces";
 
+import { Logger } from "../src/logger";
+
+
 /**
  * 
  */
@@ -65,7 +68,8 @@ describe("networkManager tests", () => {
     beforeEach(done => {
         sessionManager = new MockSessionmanager();
         socketManager = new MockWebSocketManager();
-        networkManager = new NetworkManager(sessionManager, socketManager);
+        let logger = new Logger();
+        networkManager = new NetworkManager(logger, sessionManager, socketManager);
         done();
     });
 

--- a/specs/webSocket.spec.ts
+++ b/specs/webSocket.spec.ts
@@ -45,6 +45,9 @@ describe("webSocket Manager tests", () => {
         public startSession(): Promise<ISessionInfo> { return Promise.resolve(null); }
         public endSession(): Promise<boolean> { return Promise.resolve(true); }
         public ensureSession(): Promise<ISessionInfo> { return Promise.resolve(this.sessionInfo); }
+        public requestSession(): Promise<ISessionInfo> { return Promise.resolve(this.sessionInfo); }
+        public removeSession() { return Promise.resolve(false); }
+
     }
 
     /**
@@ -259,14 +262,11 @@ describe("webSocket Manager tests", () => {
         comapiConfig.webSocketBase = "ws://junk";
 
         webSocketManager.connect()
-            .then(function () {
-                fail("Should not be in here");
-                done();
-            })
-            .catch(function () {
+            .then(function (connected) {
                 let isConnected = webSocketManager.isConnected();
                 console.log("isConnected = " + isConnected);
                 expect(isConnected).toBeFalsy();
+                expect(connected).toBeFalsy();
                 done();
             });
     });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -211,6 +211,8 @@ export interface ISessionManager {
     getValidToken(): Promise<string>;
     startSession(): Promise<ISessionInfo>;
     endSession(): Promise<boolean>;
+    requestSession(): Promise<any>;
+    removeSession(): Promise<boolean>;
 }
 
 /**

--- a/src/networkManager.ts
+++ b/src/networkManager.ts
@@ -5,6 +5,7 @@ import {
     IWebSocketManager,
     ISessionInfo,
     ISession,
+    ILogger,
     INetworkManager
 } from "./interfaces";
 
@@ -21,7 +22,8 @@ export class NetworkManager implements INetworkManager {
      * @parameter {ISessionManager} _sessionManager 
      * @parameter {IWebSocketManager} _webSocketManager 
      */
-    constructor(@inject(INTERFACE_SYMBOLS.SessionManager) private _sessionManager: ISessionManager,
+    constructor(@inject(INTERFACE_SYMBOLS.Logger) private _logger: ILogger,
+        @inject(INTERFACE_SYMBOLS.SessionManager) private _sessionManager: ISessionManager,
         @inject(INTERFACE_SYMBOLS.WebSocketManager) private _webSocketManager: IWebSocketManager) { }
 
 
@@ -42,7 +44,7 @@ export class NetworkManager implements INetworkManager {
                 if (connected) {
                     return _sessionInfo;
                 } else {
-                    console.error("Failed to connect web socket");
+                    this._logger.error("Failed to connect web socket");
 
                     // Is the session invalid even though it hadn't expired ? 
                     //  - perhaps the auth settings have changes since the token was issued ?
@@ -51,9 +53,9 @@ export class NetworkManager implements INetworkManager {
                             // all good, websocket connection failure was just a blip and will automatically reconnect ...
                             return _sessionInfo;
                         })
-                        .catch(error2 => {
+                        .catch(error => {
                             // session was bad
-                            console.error("failed to request session", error2);
+                            this._logger.error("failed to request session", error);
                             // delete old cached session and re-auth ...
                             return this._sessionManager.removeSession()
                                 .then(result => {
@@ -84,7 +86,7 @@ export class NetworkManager implements INetworkManager {
             })
             .then(([sessionInfo, connected]) => {
                 if (!connected) {
-                    console.error("Failed to connect web socket");
+                    this._logger.error("Failed to connect web socket");
                 }
 
                 return sessionInfo;


### PR DESCRIPTION
Tokens on Prod. are valid for 1 month. If auth settings have been modified since token issue, that token will be be invalid. SDK won't know this until it goes to use it, there web a hole in the web-socket logic where it would not retry if the connection failed when a session was started. This patch fixes that.