### PR TITLE
robustly determine platformVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comapi-sdk-js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "scripts": {
     "test": "karma start --browsers=ChromeHeadless"
   },
@@ -12,7 +12,7 @@
     "url": "https://github.com/comapi/comapi-sdk-js/issues"
   },
   "dependencies": {
-    "@types/jasmine": "^2.5.35",
+    "@types/jasmine": "2.5.35",
     "grunt-ts": "^6.0.0-beta.16",
     "inversify": "^4.1.1",
     "jasmine-core": "^2.4.1",
@@ -50,6 +50,6 @@
     "webpack": "^1.13.3",
     "ws": "^3.3.1"
   },
-  "build": "322",
+  "build": "327",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "webpack": "^1.13.3",
     "ws": "^3.3.1"
   },
-  "build": "327",
+  "build": "328",
   "license": "MIT"
 }

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -208,7 +208,19 @@ export class SessionManager implements ISessionManager {
 
         return this.getDeviceId()
             .then(() => {
-                let browserInfo = Utils.getBrowserInfo();
+                let platformVersion = "Unknown";
+                
+                if(typeof navigator !== "undefined"){
+                    if(navigator.product === "ReactNative"){
+                        platformVersion = "ReactNative";
+                    }else if(navigator.userAgent){
+                        let browserInfo = Utils.getBrowserInfo();
+                        if(browserInfo.version){
+                            platformVersion = browserInfo.version;
+                        }                        
+                    }    
+                }
+
 
                 let data = {
                     authenticationId: authenticationId,
@@ -216,7 +228,7 @@ export class SessionManager implements ISessionManager {
 
                     deviceId: this._deviceId,
                     platform: /*browserInfo.name*/ "javascript",
-                    platformVersion: browserInfo.version,
+                    platformVersion: platformVersion,
                     sdkType: /*"javascript"*/ "native",
                     sdkVersion: "_SDK_VERSION_"
                 };

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -211,16 +211,8 @@ export class SessionManager implements ISessionManager {
                 let platformVersion = "Unknown";
                 
                 if(typeof navigator !== "undefined"){
-                    if(navigator.product === "ReactNative"){
-                        platformVersion = "ReactNative";
-                    }else if(navigator.userAgent){
-                        let browserInfo = Utils.getBrowserInfo();
-                        if(browserInfo.version){
-                            platformVersion = browserInfo.version;
-                        }                        
-                    }    
+                    platformVersion = (navigator.product !== "undefined" ? navigator.product : "Unknown") + (navigator.userAgent !== "undefined" ? " : " + navigator.userAgent : "");
                 }
-
 
                 let data = {
                     authenticationId: authenticationId,


### PR DESCRIPTION
**Whats changed:**

navigator.userAgent was being used to determine platformVersion without checking its validity. 
If the SDK is being consumed in react-native environment, this was failing.
This patch now robustly determines platformVersion.

**Reason for change**

To remove the dependency of navigator.userAgent in the react-native environment