### PR TITLE
Updated docs to ensure jwt signing includes the utf8 option

### DIFF
--- a/docs/initialisation.md
+++ b/docs/initialisation.md
@@ -162,7 +162,7 @@ function authChallenge (options, answerAuthenticationChallenge) {
     };
     var sHeader = JSON.stringify(oHeader);
     var sPayload = JSON.stringify(oPayload);
-    var sJWT = KJUR.jws.JWS.sign("HS256", sHeader, sPayload, "my shared secret");
+    var sJWT = KJUR.jws.JWS.sign("HS256", sHeader, sPayload, {utf8: "my shared secret"});
     answerAuthenticationChallenge(sJWT);
 }
 ```


### PR DESCRIPTION
Updated docs to ensure jwt signing includes the utf8 option - default secrets generated in the comapi portal look like hex strings and jsrassign performs an unwanted cast without this option.